### PR TITLE
Switch to 301 redirects

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,7 +5,7 @@ export default (redirectUrl: string) =>
   class extends React.Component {
     static async getInitialProps({ res }) {
       if (res) {
-        res.writeHead(302, { Location: redirectUrl })
+        res.writeHead(301, { Location: redirectUrl })
         res.end()
       } else {
         Router.push(redirectUrl)

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
 import Router from 'next/router'
 
-export default (redirectUrl: string) =>
+export default (redirectUrl: string, statusCode = 301) =>
   class extends React.Component {
     static async getInitialProps({ res }) {
       if (res) {
-        res.writeHead(301, { Location: redirectUrl })
+        res.writeHead(statusCode, { Location: redirectUrl })
         res.end()
       } else {
         Router.push(redirectUrl)


### PR DESCRIPTION
302 is for temporary redirects, while [301 is for permanent redirects](https://blog.rebrandly.com/url-redirects/). 301 lets search engines know that the desired content will *always* be at the redirected location—it's the redirect type that URL shorteners like [Bitly](https://bitly.com) use. I assume that's your intent with https://pablo.pink/donate, where you don't ever plan on hosting the PayPal content directly at https://pablo.pink/donate itself. That's how I plan to use it.

Great little tool, by the way; thanks for making this, @pablopunk!