### PR TITLE
Extend client-side redirects

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "url": "https://github.com/pablopunk/nextjs-redirect"
   },
   "scripts": {
-    "build": "sucrase src -d dist --transforms imports,typescript && npm run generate-types && npm run prettier",
+    "build": "sucrase src -d dist --transforms imports,typescript,jsx && npm run generate-types && npm run prettier",
     "generate-types": "dts-bundle-generator -o typings.d.ts src/index.tsx",
     "prettier": "prettier src/*.tsx ./typings.d.ts --write",
     "prepare": "npm run build"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "jsx": "react",
     "target": "es5",
     "lib": ["dom", "dom.iterable", "esnext"],
     "skipLibCheck": true,

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -8,6 +8,7 @@ declare const _default: (
   }
 ) => {
   new (): {
+    componentDidMount(): void
     render(): any
   }
   getInitialProps({ res }: { res: any }): Promise<{}>


### PR DESCRIPTION
Hey! Had some ideas for client-side redirects, since my site runs on GitHub Pages and can't use the server-side stuff.

1. nextjs-redirect currently doesn't work with Next's [static HTML export](https://nextjs.org/docs/advanced-features/static-html-export) because it runs `getInitialProps` just once on export and then doesn't make it available to the static client. During this static export, it makes it inside `getInitialProps`'s `if (res)` block just fine but then fails on `res.writeHead`, saying it isn't a function. So I changed the condition to `if (res?.writeHead)` instead, so it'll only make it into that block if it's on the server-side but skip it during the static export.

2. Because `getInitialProps` doesn't make it to the client after a static export, I moved the `Router.push` lines inside a `componentDidMount`. I also added a couple lines to use `window.location.href` for external URLs instead of `Router.push`, since the Next.js docs say [that's a better option](https://nextjs.org/docs/api-reference/next/router#routerpush).

3. I added a meta refresh surrounded by a `<noscript>` to the `<head>` of the page for a fallback in case the client has disabled JavaScript.

4. I also added a canonical link when `statusCode` is `301` (or not set) so search engines know where to send the link juice when there's no server to send an actual 301 code.

5. And finally, I added a redirect link within the actual `<body>` just in case a user doesn't get redirected by the other three methods.

Also, the reason I put the children of `next/head` inside an explicit `children` attribute is because TypeScript and/or Sucrase was giving me errors when I tried to add children the normal way. So I decided I didn't want to deal with it. ¯\_(ツ)_/¯

Thoughts? Is it too much added?