### PR TITLE
fix: avoid render-time param redirects throwing [ai]

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -67,8 +67,12 @@ export default (
     render() {
       let href = options?.asUrl ?? redirectUrl
 
-      if (options?.params != null) {
-        href = getParamFromClient(redirectUrl)
+      if (options?.params === true && typeof window !== 'undefined') {
+        try {
+          href = getParamFromClient(redirectUrl)
+        } catch {
+          // Keep the fallback href when the query parameter is unavailable during render.
+        }
       }
 
       return (


### PR DESCRIPTION
## What
Avoid throwing during render when params-based redirects are missing their query param.

## Found by
Scanner category: bug

## Fix
Only resolve params in render when `params: true` and the browser is available, and keep the fallback href if the query param is absent. Redirect behavior still runs in `getInitialProps`/`componentDidMount`.

## Tested
- [x] `npm run build` passes
- [x] Independent review passed via Pi reviewer (no new security or logic errors)
- [ ] Manually verified: consumer app render path with missing param

🤖 *[ai] — auto-fix by Hermes Autonomous Orchestrator*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved redirect handling when query parameters are read during rendering.
  * If the redirect value can’t be determined from the current URL, the app now safely falls back to the existing destination instead of failing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->